### PR TITLE
Changed check to look for direct messages instead of hardcoded channe…

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -112,10 +112,10 @@ func (b *Bot) Init(rtm *slack.RTM) error {
 	params := slack.PostMessageParameters{AsUser: true}
 	_, _, err = b.slackBotAPI.PostMessage(b.users["dlsniper"], fmt.Sprintf(`Deployed version: %s`, b.version), params)
 	if err != nil {
-		b.logf("Failed to send deploy version message.")
+		b.logf(`failed to deploy version: %s`, b.version)
 	}
 
-	return nil
+	return err
 }
 
 // TeamJoined is called when the someone joins the team

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -111,8 +111,11 @@ func (b *Bot) Init(rtm *slack.RTM) error {
 
 	params := slack.PostMessageParameters{AsUser: true}
 	_, _, err = b.slackBotAPI.PostMessage(b.users["dlsniper"], fmt.Sprintf(`Deployed version: %s`, b.version), params)
+	if err != nil {
+		b.logf("Failed to send deploy version message.")
+	}
 
-	return err
+	return nil
 }
 
 // TeamJoined is called when the someone joins the team
@@ -167,7 +170,7 @@ func (b *Bot) isBotMessage(event *slack.MessageEvent, eventText string) bool {
 		strings.HasPrefix(eventText, strings.ToLower("<@"+b.id+">:")) ||
 		strings.HasPrefix(eventText, "gopher ") ||
 		strings.HasPrefix(eventText, "gopher: ") ||
-		event.Channel == b.channels["gopher"].slackID
+		strings.HasPrefix(event.Channel, "D") // Direct message channels always starts with 'D'
 }
 
 func (b *Bot) trimBot(msg string) string {
@@ -726,9 +729,6 @@ func NewBot(ctx context.Context, slackBotAPI *slack.Client, dsClient *datastore.
 			"general":    {description: "general channel", special: true},
 			"golang_cls": {description: "https://twitter.com/golang_cls", special: true},
 			"golang-cls": {description: "https://twitter.com/golang_cls", special: true},
-
-			// Do NOT touch the ID on this one
-			"gopher": {description: "direct message channel with Gopher", special: true, slackID: "D258JJQ13"},
 		},
 	}
 }


### PR DESCRIPTION
Each user has a different direct message channel id when sending messages to the bot.
Currently, there is no way in the Slack API to check if the message was sent as a direct message, channel or private channel.

I did however noticed that all Direct message channel id's started with capital 'D'. Since I couldn't find anything about it in the Slack API documentation I asked the support and got an answer from James Holloway at Slack.

When I asked if it was safe to assume that all direct message channel ids will start with capital D he replied: "it's safe to assume this. Along with C for a public channel and G for a private one."