### PR TITLE
bot.go: playground hint as thread when available

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -711,7 +711,7 @@ func (b *Bot) suggestPlayground2(ctx context.Context, event *slack.MessageEvent)
 		return
 	}
 
-	params := slack.PostMessageParameters{AsUser: true}
+	params := slack.PostMessageParameters{AsUser: true, ThreadTimestamp: event.ThreadTimestamp}
 	_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.Channel, `The above code in playground: <https://play.golang.org/p/`+string(linkID)+`>`, params)
 	if err != nil {
 		b.logf("%s\n", err)


### PR DESCRIPTION
When a wall of text is posted in thread, Gopher hints the playground link to the channel. This PR copies any `thread_ts` from the input message to output message which should result in the playground link being posted to the thread.

Non-threaded messages should have empty strings; threaded messages should have the parent's `ts` value.

As the `slack` package unmarshals with `omitempty` and marshals without it, we're already sending empty string `thread_ts` values to slack.

Don't have a slack to test this