### PR TITLE
Proposal: Only suggest the Go playground when there is a main function in main package

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -637,7 +637,7 @@ func (b *Bot) suggestPlayground2(ctx context.Context, event *slack.MessageEvent)
 	start := strings.Index(originalEventText, "package main")
 	end := strings.LastIndex(originalEventText, "}")
 	if end == -1 {
-		return // return because it won't run on the playground
+		return // playground won't run without a brace to close the main function body
 	}
 
 	runes := []rune(originalEventText)

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -633,6 +633,16 @@ func (b *Bot) suggestPlayground2(ctx context.Context, event *slack.MessageEvent)
 	eventText := ""
 
 	// Be nice and try to first figure out if there's any possible code in there
+	start := strings.Index(originalEventText, "package main")
+	end := strings.LastIndex(originalEventText, "}")
+
+	if start == -1 || end == -1 {
+		return // return because it won't run on the playground
+	}
+
+	runes := []rune(originalEventText)
+	eventText = string(runes[start : end+1]) // start at the package declaration and end with the last close
+
 	/* This has a bug so don't be nice for now
 	for dotPos := strings.Index(originalEventText, "```"); dotPos != -1;  dotPos = strings.Index(originalEventText, "```") {
 		originalEventText = originalEventText[dotPos+3:]

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -406,7 +406,8 @@ func (b *Bot) HandleMessage(event *slack.MessageEvent) {
 
 	// We assume that the user actually wanted to have a code snippet shared
 	if !strings.HasPrefix(eventText, "nolink") &&
-		strings.Count(eventText, "\n") > 9 {
+		strings.Contains(eventText, "package main") && // Need a main package and function to run
+		strings.Contains(eventText, "func main()" {
 		b.suggestPlayground2(ctx, event)
 		return
 	}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -636,8 +636,7 @@ func (b *Bot) suggestPlayground2(ctx context.Context, event *slack.MessageEvent)
 	// Be nice and try to first figure out if there's any possible code in there
 	start := strings.Index(originalEventText, "package main")
 	end := strings.LastIndex(originalEventText, "}")
-
-	if start == -1 || end == -1 {
+	if end == -1 {
 		return // return because it won't run on the playground
 	}
 


### PR DESCRIPTION
Gopherbot has been known to troll channels like #golang-jobs by suggesting the Go playground for long messages. That behavior is being set off by this check: `strings.Count(eventText, "\n") > 9`

The bot has been kicked out of the jobs channel, but the issue still pops up elsewhere if anyone writes out a long message or posts a long non-Go snippet, like terminal output. 

My proposed change here is to restrict the playground suggestions to pieces of code that should be able to run in the playground as-is. Namely, scripts with a "package main" statement that also contain a main function. 

To reduce false-positives this change will exclude shorter snippets of valid Go code that require some elbow-grease to run in the playground. 

ie. 
```go
switch token := tokens.Next(); token {
        case html.ErrorToken:
            return
        case html.StartTagToken:
            t := tokens.Token()
            isAnchor := t.Data == "a"
            if isAnchor {
                fmt.Println("We found a link")
                i++
            }
        }
```