### PR TITLE
newbie resources: update tour link to use https

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -485,7 +485,7 @@ func newbieResourcesPrivate(ctx context.Context, b *Bot, event *slack.MessageEve
 
 func newbieResources(ctx context.Context, b *Bot, event *slack.MessageEvent, private bool) {
 	newbieResources := slack.Attachment{
-		Text: `First you should take the language tour: <http://tour.golang.org/>
+		Text: `First you should take the language tour: <https://tour.golang.org/>
 
 Then, you should visit:
  - <https://golang.org/doc/code.html> to learn how to organize your Go workspace


### PR DESCRIPTION
The other links with working HTTPS support are already using the `https` scheme.
Let's do the same for the tour.

Signed-off-by: Tim Heckman <t@heckman.io>