### PR TITLE
post alternate platform song links

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -784,7 +784,7 @@ func xkcd(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 }
 
 var regexSongNolink = regexp.MustCompile(`(?i)(nolink|song\.link)`)
-var regexSongLink = regexp.MustCompile(`(i?)(open\.spotify\.com|spotify:[a-z]|soundcloud\.com|tidal\.com)/[^\s]+`)
+var regexSongLink = regexp.MustCompile(`(?i)(?:https?://)?(open\.spotify\.com/|spotify:|soundcloud\.com/|tidal\.com/)[^\s]+`)
 
 func songLinkHandler(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	msg, params := songlink(event)
@@ -805,6 +805,7 @@ func songlink(event *slack.MessageEvent) (string, slack.PostMessageParameters) {
 	if regexSongNolink.MatchString(event.Text) || !regexSongLink.MatchString(event.Text) {
 		return "", slack.PostMessageParameters{}
 	}
+
 	var out string
 	links := regexSongLink.FindAllString(event.Text, -1)
 	for _, link := range links {

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -798,7 +798,9 @@ func songLinkHandler(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	}
 }
 
-// func songlink(ctx context.Context, b *Bot, event *slack.MessageEvent) {
+// songlink inspects the message for Spotify, Soundcloud, Tidal links
+// It returns empty string when no reply is needed
+// Otherwise it returns the reply text and params configured for threaded reply
 func songlink(event *slack.MessageEvent) (string, slack.PostMessageParameters) {
 	if regexSongNolink.MatchString(event.Text) || !regexSongLink.MatchString(event.Text) {
 		return "", slack.PostMessageParameters{}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -784,7 +784,7 @@ func xkcd(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 }
 
 var regexSongNolink = regexp.MustCompile(`(?i)(nolink|song\.link)`)
-var regexSongLink = regexp.MustCompile(`(i?)https?://(open\.spotify\.com|soundcloud\.com|tidal\.com)/[^\s]+`)
+var regexSongLink = regexp.MustCompile(`(i?)(open\.spotify\.com|spotify:[a-z]|soundcloud\.com|tidal\.com)/[^\s]+`)
 
 func songLinkHandler(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	msg, params := songlink(event)

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -783,8 +783,8 @@ func xkcd(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	}
 }
 
-var regexSongNolink = regexp.MustCompile(`(?i)song\.link`)
-var regexSongLink = regexp.MustCompile(`(i?)https?://(open\.spotify\.com|soundcloud\.com|tidal.com)/[^\s]+`)
+var regexSongNolink = regexp.MustCompile(`(?i)(nolink|song\.link)`)
+var regexSongLink = regexp.MustCompile(`(i?)https?://(open\.spotify\.com|soundcloud\.com|tidal\.com)/[^\s]+`)
 
 func songLinkHandler(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	msg, params := songlink(event)

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -1,0 +1,81 @@
+package bot
+
+import (
+	"testing"
+
+	"github.com/nlopes/slack"
+)
+
+func TestSongLink(t *testing.T) {
+	testMsg := func(text string) *slack.MessageEvent {
+		return &slack.MessageEvent{
+			Msg: slack.Msg{
+				Text:            text,
+				Timestamp:       "1000",
+				ThreadTimestamp: "1200",
+			},
+		}
+	}
+
+	t.Run("skips https://google.com/a", func(t *testing.T) {
+		in := testMsg("https://google.com/a")
+		expected := ""
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
+	t.Run("skips https://song.link/https://open.spotify.com/track", func(t *testing.T) {
+		in := testMsg("<https://song.link/https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>")
+		expected := ""
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
+	t.Run("detects http://open.spotify.com/a", func(t *testing.T) {
+		in := testMsg("[drum and bass, uk hardcore, jazz, gospel] https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ")
+		expected := "<https://song.link/https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>"
+		msg, params := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+		if params.ThreadTimestamp != in.ThreadTimestamp {
+			t.Errorf("expected output to follow OP's thread, got %s", params.ThreadTimestamp)
+		}
+		if params.UnfurlMedia == true || params.UnfurlLinks == true {
+			t.Error("expected output to collapse everything")
+		}
+	})
+
+	t.Run("detects https://soundcloud.com/a/b", func(t *testing.T) {
+		in := testMsg("check out https://soundcloud.com/lematos/highway-64-1")
+		expected := "<https://song.link/https://soundcloud.com/lematos/highway-64-1>"
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
+	t.Run("detects https://tidal.com/a/1", func(t *testing.T) {
+		in := testMsg("https://tidal.com/album/86024647")
+		expected := "<https://song.link/https://tidal.com/album/86024647>"
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
+	t.Run("handles multiple links", func(t *testing.T) {
+		in := testMsg("check out https://soundcloud.com/kennedyjones/gramatikkennedyjones and https://open.spotify.com/track/5Fwq7F2yjF3eQnvkfjN4LY fellow gophers")
+		expected := `<https://song.link/https://soundcloud.com/kennedyjones/gramatikkennedyjones>
+<https://song.link/https://open.spotify.com/track/5Fwq7F2yjF3eQnvkfjN4LY>`
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
+}

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -35,6 +35,15 @@ func TestSongLink(t *testing.T) {
 		}
 	})
 
+	t.Run("skips https://SONG.LINK/https://open.spotify.com/track", func(t *testing.T) {
+		in := testMsg("<https://SONG.LINK/https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>")
+		expected := ""
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
 	t.Run("skips nolink https://open.spotify.com/track", func(t *testing.T) {
 		in := testMsg("noLink <https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>")
 		expected := ""

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -59,6 +59,15 @@ func TestSongLink(t *testing.T) {
 		}
 	})
 
+	t.Run("detects spotify:album:54OM8icMyeUMzhpJn8Igmk", func(t *testing.T) {
+		in := testMsg("spotify:album:54OM8icMyeUMzhpJn8Igmk")
+		expected := "<https://song.link/spotify:album:54OM8icMyeUMzhpJn8Igmk>"
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
 	t.Run("detects https://soundcloud.com/a/b", func(t *testing.T) {
 		in := testMsg("check out https://soundcloud.com/lematos/highway-64-1")
 		expected := "<https://song.link/https://soundcloud.com/lematos/highway-64-1>"

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -35,6 +35,15 @@ func TestSongLink(t *testing.T) {
 		}
 	})
 
+	t.Run("skips nolink https://open.spotify.com/track", func(t *testing.T) {
+		in := testMsg("noLink <https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>")
+		expected := ""
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
 	t.Run("detects http://open.spotify.com/a", func(t *testing.T) {
 		in := testMsg("[drum and bass, uk hardcore, jazz, gospel] https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ")
 		expected := "<https://song.link/https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>"

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -44,6 +44,15 @@ func TestSongLink(t *testing.T) {
 		}
 	})
 
+	t.Run("ignores `Wait, does Slack recognize the Spotify URIs now?`", func(t *testing.T) {
+		in := testMsg("Wait, does Slack recognize the Spotify URIs now?")
+		expected := ""
+		msg, _ := songlink(in)
+		if msg != expected {
+			t.Errorf("expected: %q\nactual:%q", expected, msg)
+		}
+	})
+
 	t.Run("detects http://open.spotify.com/a", func(t *testing.T) {
 		in := testMsg("[drum and bass, uk hardcore, jazz, gospel] https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ")
 		expected := "<https://song.link/https://open.spotify.com/track/0nypsuS2jtogLaJDcRQ4Ya?si=wqgnW8jeS9aYEqWagrDadQ>"


### PR DESCRIPTION
I want to hear posts in #howplaying without creating a spotify account or manually looking up each track.

https://song.link associates the same song across many platforms. This PR makes gopher reply as thread with those alternatives when it sees spotify, soundcloud or tidal links.

input: https://open.spotify.com/album/4xMlG8lVUmeselxOxrwi1b?si=ID6hhknTTquEQwB2KQjLRg`
output: https://song.link/https://open.spotify.com/album/4xMlG8lVUmeselxOxrwi1b?si=ID6hhknTTquEQwB2KQjLRg

I've assumed that `event.Text` contains unmangled links.