### PR TITLE
Update order of the slices message to build context

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -269,8 +269,8 @@ var (
 		},
 		"slices": {
 			`The following posts will explain how slices, maps and strings work in Go:`,
-			`- <https://blog.golang.org/slices>`,
 			`- <https://blog.golang.org/go-slices-usage-and-internals>`,
+			`- <https://blog.golang.org/slices>`,
 			`- <https://blog.golang.org/strings>`,
 		},
 		"database tutorial": {


### PR DESCRIPTION
This change proposes moving the original "Go Slices, Usage, and Internals" blog
post to be the first link provided, to set some foundational context around
slices. This blog post is also shorter than the "slices" one.

Signed-off-by: Tim Heckman <t@heckman.io>