### PR TITLE
Update flipCoin function to be more correct / idiomatic

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -820,17 +820,17 @@ func botVersion(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 }
 
 func flipCoin(ctx context.Context, b *Bot, event *slack.MessageEvent) {
-	buff := make([]byte, 1, 1)
+	buff := make([]byte, 1)
 	_, err := rand.Read(buff)
 	if err != nil {
 		b.logf("%s\n", err)
 	}
 	result := "heads"
 	if buff[0]%2 == 0 {
-		result = "tail"
+		result = "tails"
 	}
 	params := slack.PostMessageParameters{AsUser: true}
-	_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.Channel, fmt.Sprintf("%s", result), params)
+	_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.Channel, result, params)
 	if err != nil {
 		b.logf("%s\n", err)
 		return


### PR DESCRIPTION
- use the term "tails" instead of "tail" (fixes #28)
- when making a slice, if the capacity is the same as the length you can omit
  the length
- remove redundant Sprintf statement

Signed-off-by: Tim Heckman <t@heckman.io>