### PR TITLE
Add thread support to more functions

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -215,18 +215,18 @@ func (b *Bot) specialRestrictions(restriction string, event *slack.MessageEvent)
 var (
 	// Generic responses to all messages
 	containsToReactions = map[string][]string{
-		"︵": {"┬─┬ノ( º _ ºノ)"},
-		"彡": {"┬─┬ノ( º _ ºノ)"},
+		"︵":                          {"┬─┬ノ( º _ ºノ)"},
+		"彡":                          {"┬─┬ノ( º _ ºノ)"},
 		"my adorable little gophers": {"gopher"},
-		"bbq":       {"bbqgopher"},
-		"buffalo":   {"gobuffalo"},
-		"gobuffalo": {"gobuffalo"},
-		"ghost":     {"ghost"},
-		"ermergerd": {"dragon"},
-		"ermahgerd": {"dragon"},
-		"dragon":    {"dragon"},
-		"spacex":    {"rocket"},
-		"beer me":   {"beer", "beers"},
+		"bbq":                        {"bbqgopher"},
+		"buffalo":                    {"gobuffalo"},
+		"gobuffalo":                  {"gobuffalo"},
+		"ghost":                      {"ghost"},
+		"ermergerd":                  {"dragon"},
+		"ermahgerd":                  {"dragon"},
+		"dragon":                     {"dragon"},
+		"spacex":                     {"rocket"},
+		"beer me":                    {"beer", "beers"},
 	}
 
 	reactWithMessage = map[string]struct{}{
@@ -702,7 +702,7 @@ func respond(ctx context.Context, b *Bot, event *slack.MessageEvent, response st
 		b.logf("should reply to message %s with %s\n", event.Text, response)
 		return
 	}
-	params := slack.PostMessageParameters{AsUser: true}
+	params := slack.PostMessageParameters{AsUser: true, ThreadTimestamp: event.ThreadTimestamp}
 	_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.Channel, response, params)
 	if err != nil {
 		b.logf("%s\n", err)
@@ -731,7 +731,7 @@ func searchLibrary(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 		return
 	}
 	searchTerm = url.QueryEscape(searchTerm)
-	params := slack.PostMessageParameters{AsUser: true}
+	params := slack.PostMessageParameters{AsUser: true, ThreadTimestamp: event.ThreadTimestamp}
 	_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.Channel, `You can try to look here: <https://godoc.org/?q=`+searchTerm+`> or here <http://go-search.org/search?q=`+searchTerm+`>`, params)
 	if err != nil {
 		b.logf("%s\n", err)
@@ -769,9 +769,10 @@ func xkcd(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	imageLink := fmt.Sprintf("<https://xkcd.com/%d/>", comicID)
 
 	params := slack.PostMessageParameters{
-		AsUser:      true,
-		UnfurlLinks: true,
-		UnfurlMedia: true,
+		AsUser:          true,
+		ThreadTimestamp: event.ThreadTimestamp,
+		UnfurlLinks:     true,
+		UnfurlMedia:     true,
 	}
 	_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.Channel, imageLink, params)
 	if err != nil {
@@ -786,7 +787,7 @@ func (b *Bot) godoc(ctx context.Context, event *slack.MessageEvent, prefix strin
 		link = link[:strings.Index(link, " ")]
 	}
 
-	params := slack.PostMessageParameters{AsUser: true}
+	params := slack.PostMessageParameters{AsUser: true, ThreadTimestamp: event.ThreadTimestamp}
 	_, _, err := b.slackBotAPI.PostMessageContext(ctx, event.Channel, `<https://godoc.org/`+prefix+link+`>`, params)
 	if err != nil {
 		b.logf("%s\n", err)
@@ -829,7 +830,7 @@ func flipCoin(ctx context.Context, b *Bot, event *slack.MessageEvent) {
 	if buff[0]%2 == 0 {
 		result = "tail"
 	}
-	params := slack.PostMessageParameters{AsUser: true}
+	params := slack.PostMessageParameters{AsUser: true, ThreadTimestamp: event.ThreadTimestamp}
 	_, _, err = b.slackBotAPI.PostMessageContext(ctx, event.Channel, fmt.Sprintf("%s", result), params)
 	if err != nil {
 		b.logf("%s\n", err)


### PR DESCRIPTION
This PR adds Slack thread support to more functions in the bot. Thread support was already present in the playground linking but not in e.g. the `respond` function.